### PR TITLE
Fix code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ioredis": "5.4.1",
     "redis": "4.6.14",
     "serve-static": "2.1.0",
-    "sharp": "0.33.5"
+    "sharp": "0.33.5",
+    "fastify-rate-limit": "^5.9.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,12 @@ const {join, basename, normalize, resolve} = require("node:path");
 const {createReadStream, path} = require("fs");
 // Fastify
 const server = require('fastify')({logger: true});
+const rateLimit = require('fastify-rate-limit');
+
+server.register(rateLimit, {
+  max: 100, // maximum number of requests
+  timeWindow: '15 minutes' // time window for the rate limit
+});
 
 // Server Routing Mechanic
 
@@ -17,7 +23,7 @@ function loadRoute(routeOption) {
 
 
 server
-    .get(`/${process.env.PATH_IDENTIFIER}/css/:asset`, (req, rep) => {
+    .get(`/${process.env.PATH_IDENTIFIER}/css/:asset`, { config: { rateLimit: { max: 100, timeWindow: '15 minutes' } } }, (req, rep) => {
       const reg = /\.css$/.test(req.params.asset);
       if (!reg) {
         return false;
@@ -38,7 +44,7 @@ server
             .send(stream || null);
       }
     })
-    .get(`/${process.env.PATH_IDENTIFIER}/fonts/:asset`, (req, rep) => {
+    .get(`/${process.env.PATH_IDENTIFIER}/fonts/:asset`, { config: { rateLimit: { max: 100, timeWindow: '15 minutes' } } }, (req, rep) => {
       const reg = /\.ttf$/.test(req.params.asset);
       if (!reg) {
         return false;
@@ -54,7 +60,7 @@ server
           })
           .send(stream || null);
     })
-    .get(`/${process.env.PATH_IDENTIFIER}/js/:asset`, (req, rep) => {
+    .get(`/${process.env.PATH_IDENTIFIER}/js/:asset`, { config: { rateLimit: { max: 100, timeWindow: '15 minutes' } } }, (req, rep) => {
       const reg = /\.js$/.test(req.params.asset);
       if (!reg) {
         return false;
@@ -70,7 +76,7 @@ server
           })
           .send(stream || null);
     })
-    .get(`/${process.env.PATH_IDENTIFIER}/lang/lang.json`, (req, rep) => {
+    .get(`/${process.env.PATH_IDENTIFIER}/lang/lang.json`, { config: { rateLimit: { max: 100, timeWindow: '15 minutes' } } }, (req, rep) => {
         const stream = createReadStream(join(__dirname, "/lang/lang.json"));
         rep.headers({
             "Content-Type": "application/json",


### PR DESCRIPTION
Fixes [https://github.com/akama-aka/cdn-cgi/security/code-scanning/1](https://github.com/akama-aka/cdn-cgi/security/code-scanning/1)

To fix the problem, we need to introduce rate limiting to the routes that perform file system access. The best way to do this is by using a rate-limiting middleware, such as `express-rate-limit`, which can be easily integrated with the Fastify framework using the `fastify-rate-limit` plugin.

1. Install the `fastify-rate-limit` plugin.
2. Register the `fastify-rate-limit` plugin with the Fastify server.
3. Apply the rate limiter to the specific routes that perform file system access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
